### PR TITLE
fixbug: 修复BasicTree 获取选中节点bug

### DIFF
--- a/vben28/src/views/admin/roles/PermissionAbpRole.vue
+++ b/vben28/src/views/admin/roles/PermissionAbpRole.vue
@@ -79,7 +79,7 @@ export default defineComponent({
       totalRolePermissionsRef.forEach((item:string)=>{
          let permisstion = new UpdatePermissionDto();
             permisstion.name = item;
-          if((keys.checked as []).some(e=>e==item)){
+          if (((keys.checked ? keys.checked : keys) as []).some((e) => e == item)) {
             permisstion.isGranted = true;
             permisstions.push(permisstion);
           }else{


### PR DESCRIPTION
在没有触发Check事件的情况下 getCheckedKeys()无法获取选中节点